### PR TITLE
feature: 비동기를 통한 성능 최적화

### DIFF
--- a/backend/src/main/java/kakaobootcamp/backend/common/async/AsyncConfig.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/async/AsyncConfig.java
@@ -1,0 +1,9 @@
+package kakaobootcamp.backend.common.async;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/email/EmailService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/email/EmailService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +36,7 @@ public class EmailService {
 	private static final String EMAIL_TEXT = "인증 코드는 %d 입니다.";
 
 	// 이메일 인증번호 보내기
+	@Async
 	@Transactional(rollbackFor = ApiException.class)
 	public void validateEmailAndSendEmailVerification(SendVerificationCodeRequest request) {
 		String email = request.getEmail();
@@ -74,7 +76,7 @@ public class EmailService {
 	}
 
 	// 이메일 보내기
-	private void sendEmail(
+	public void sendEmail(
 		String toEmail,
 		String title,
 		String text

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/StockService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/StockService.java
@@ -73,7 +73,6 @@ public class StockService {
 		if (!response.getRt_cd().equals("0")) {
 			throw ApiException.of(HttpStatus.BAD_REQUEST, response.getMsg1());
 		}
-
 	}
 
 	// 주식 사기

--- a/backend/src/main/java/kakaobootcamp/backend/domains/transaction/dto/TransactionDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/transaction/dto/TransactionDTO.java
@@ -43,7 +43,6 @@ public class TransactionDTO {
 	@Getter
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-
 	public static class FindTransactionResponse {
 
 		private boolean existence;


### PR DESCRIPTION
## issue
- close #53 

# 구현 의도
- 이메일 인증 기능의 경우, 외부 API를 통해 유저에게 이메일을 보내는 상황에서 병목이 발생했습니다.
- 많은 요청이 발생할 때 병목으로 인해 SQLException과 이메일 전송실패  장애가 나는 것을 해결하려 합니다.
- SQLException은 Connection 대기가 30초 이상 길어져서 발생했습니다.
- 이메일 전송 실패의 경우, HikariCP 부족으로 인해 발생하였습니다.

# 구현 사항
##  이메일 전송 기능을 비동기화
이메일 전송 기능의 경우 동기 방식에서 비동기  방식으로 변경
## 1. 기존 기능 성능 테스트
![image](https://github.com/user-attachments/assets/8851d430-09e5-4d7a-8025-9c6335695a30)

1초에 30번 요청한 결과 절반정도가 장애로 이어졌다.
![image](https://github.com/user-attachments/assets/2c8cc102-1779-420d-a8b7-9cb589e55c74)
비동기로 변경한 결과 장애도  발생하지 않았고, 유저 응답도 50배 빨라진 것을 볼 수있다.

##  이메일 실패 시 재전송 기능 구현
SMTP 과부하로 인해 이메일 전송을 실패했을 경우,  5초 후 재전송하도록 구현하였다.
이로 인해 동기방식을 사용했을 때에도 모든 매세지가 정상적으로 보내짐을 볼 수 있었다.

# 의문점
SMTP 과부하 에러는 google 서비스에 너무 많은 요청을 보내서 발생한 에러였다.
비동기 방식을 사용한다해도 단지 다른 스레드를 사용하는 것일 뿐인데, SMTP 에러가 왜 사라졌는 지는 모르겠다.

# 참고사항
비동기 스레드에 대한 별도의 설정은 하지 않았다.(별도의 설정이 없으면 요청시 쓰레드를 생성해서 사용한다.)
이유는 이메일 인증 기능의 경우 자주 사용되는 API가 아니므로 항상 스레드를 유지하고 있는 것은 자원 낭비라고 판단했기 때문이다.
