### PR TITLE
Feature: chatcha 기능 구현 (#64)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     //aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    // recaptcha4j 라이브러리
+    implementation 'net.tanesha.recaptcha4j:recaptcha4j:0.0.7'
+    // 구글 reCAPTCHA 사용을 위한 JSON 처리 라이브러리
+    implementation 'javax.json:javax.json-api:1.1.2'
+    implementation 'org.glassfish:javax.json:1.1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/kakaobootcamp/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
 	//500
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다."),
 	AUTO_TRADE_STATE_OFF(HttpStatus.INTERNAL_SERVER_ERROR, "자동 거래 상태가 꺼져 있습니다."),
+	CAPTCHA_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "캡차 서버에서 에러가 발생하였습니다."),
 
 	//502
 	EMAIL_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "이메일 전송에 실패하였습니다.");

--- a/backend/src/main/java/kakaobootcamp/backend/common/properties/RecaptchaProperties.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/properties/RecaptchaProperties.java
@@ -1,0 +1,15 @@
+package kakaobootcamp.backend.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "recaptcha")
+public class RecaptchaProperties {
+
+	private String secret;
+	private String url;
+}

--- a/backend/src/main/java/kakaobootcamp/backend/common/properties/config/PropertiesConfig.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/properties/config/PropertiesConfig.java
@@ -9,6 +9,7 @@ import kakaobootcamp.backend.common.properties.EmailProperties;
 import kakaobootcamp.backend.common.properties.JwtProperties;
 import kakaobootcamp.backend.common.properties.KisProperties;
 import kakaobootcamp.backend.common.properties.PublicDataPortalProperties;
+import kakaobootcamp.backend.common.properties.RecaptchaProperties;
 import kakaobootcamp.backend.common.properties.RedisProperties;
 import kakaobootcamp.backend.common.properties.SecurityProperties;
 
@@ -21,7 +22,8 @@ import kakaobootcamp.backend.common.properties.SecurityProperties;
 	CorsProperties.class,
 	EmailProperties.class,
 	AiServerProperties.class,
-	PublicDataPortalProperties.class
+	PublicDataPortalProperties.class,
+	RecaptchaProperties.class
 })
 public class PropertiesConfig {
 }

--- a/backend/src/main/java/kakaobootcamp/backend/common/util/webClient/WebClientConfig.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/util/webClient/WebClientConfig.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelOption;
 import kakaobootcamp.backend.common.properties.AiServerProperties;
 import kakaobootcamp.backend.common.properties.KisProperties;
 import kakaobootcamp.backend.common.properties.PublicDataPortalProperties;
+import kakaobootcamp.backend.common.properties.RecaptchaProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.netty.http.client.HttpClient;
@@ -23,6 +24,7 @@ public class WebClientConfig {
 	private final KisProperties kisProperties;
 	private final AiServerProperties aiServerProperties;
 	private final PublicDataPortalProperties publicDataPortalProperties;
+	private final RecaptchaProperties recaptchaProperties;
 
 	private final HttpClient httpClient = HttpClient.create()
 		.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000); // 5초
@@ -53,6 +55,17 @@ public class WebClientConfig {
 	public WebClient publicDataPortalWebClient() {
 		return WebClient.builder()
 			.baseUrl(publicDataPortalProperties.getUrl())
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE)
+			.codecs(configurer -> configurer.defaultCodecs()
+				.maxInMemorySize(2 * 1024 * 1024)) // 응답 payload가 클 경우 나는 에러 방지, 최대 2MB
+			.clientConnector(new ReactorClientHttpConnector(httpClient))
+			.build();
+	}
+
+	@Bean
+	public WebClient recaptchaWebClient() {
+		return WebClient.builder()
+			.baseUrl(recaptchaProperties.getUrl())
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE)
 			.codecs(configurer -> configurer.defaultCodecs()
 				.maxInMemorySize(2 * 1024 * 1024)) // 응답 payload가 클 경우 나는 에러 방지, 최대 2MB

--- a/backend/src/main/java/kakaobootcamp/backend/domains/recaptcha/RecaptchaController.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/recaptcha/RecaptchaController.java
@@ -1,0 +1,55 @@
+package kakaobootcamp.backend.domains.recaptcha;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import kakaobootcamp.backend.common.dto.DataResponse;
+import kakaobootcamp.backend.common.dto.ErrorResponse;
+import kakaobootcamp.backend.domains.recaptcha.dto.RecaptchaDTO.ValidateRecaptchaRequest;
+import kakaobootcamp.backend.domains.recaptcha.dto.RecaptchaDTO.ValidateRecaptchaResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/recaptcha")
+@RequiredArgsConstructor
+public class RecaptchaController {
+
+	private final RecaptchaService recaptchaService;
+
+	@PostMapping("/validate")
+	@Operation(
+		summary = "reCAPTCHA 검증",
+		description = """
+			reCAPTCHA 검증 api 입니다.""",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "성공"
+			),
+			@ApiResponse(
+				responseCode = "400",
+				description = "요청 파라미터가 잘 못 되었습니다.",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "이메일 전송에 실패하였습니다.",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+			)
+		}
+	)
+	public ResponseEntity<DataResponse<ValidateRecaptchaResponse>> validateRecaptcha(
+		@RequestBody @Valid ValidateRecaptchaRequest request) {
+		ValidateRecaptchaResponse response = recaptchaService.validateRecaptcha(request);
+
+		return ResponseEntity.ok(DataResponse.from(response));
+	}
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/recaptcha/RecaptchaService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/recaptcha/RecaptchaService.java
@@ -1,0 +1,43 @@
+package kakaobootcamp.backend.domains.recaptcha;
+
+import static kakaobootcamp.backend.common.exception.ErrorCode.*;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import kakaobootcamp.backend.common.exception.ApiException;
+import kakaobootcamp.backend.common.properties.RecaptchaProperties;
+import kakaobootcamp.backend.domains.recaptcha.dto.RecaptchaDTO.ValidateRecaptchaRequest;
+import kakaobootcamp.backend.domains.recaptcha.dto.RecaptchaDTO.ValidateRecaptchaResponse;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class RecaptchaService {
+
+	@Qualifier("recaptchaWebClient")
+	private final WebClient recaptchaWebClient;
+
+	private final RecaptchaProperties recaptchaProperties;
+
+	public ValidateRecaptchaResponse validateRecaptcha(ValidateRecaptchaRequest request) {
+		final String token = request.getToken();
+
+		return recaptchaWebClient
+			.post()
+			.uri(
+				uriBuilder -> uriBuilder
+					.queryParam("secret", recaptchaProperties.getSecret())
+					.queryParam("response", token)
+					.build())
+			.retrieve()
+			.onStatus(
+				status -> status.is4xxClientError() || status.is5xxServerError(),
+				response -> response.bodyToMono(String.class)
+					.flatMap(error -> Mono.error(ApiException.from(CAPTCHA_SERVER_ERROR))))
+			.bodyToMono(ValidateRecaptchaResponse.class)
+			.block();
+	}
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/recaptcha/dto/RecaptchaDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/recaptcha/dto/RecaptchaDTO.java
@@ -1,0 +1,25 @@
+package kakaobootcamp.backend.domains.recaptcha.dto;
+
+import static lombok.AccessLevel.*;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RecaptchaDTO {
+
+	@Getter
+	@NoArgsConstructor(access = PRIVATE)
+	public static class ValidateRecaptchaRequest {
+
+		@NotBlank
+		private String token;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = PRIVATE)
+	public static class ValidateRecaptchaResponse {
+
+		private boolean success;
+	}
+}


### PR DESCRIPTION
## issue
- close #64 

## 구현 의도 
- 로그인 실패 및 회원가입 기능에서 captcha를 도입해 브루트 포스 공격을 방지하고자 한다.

## 구현 사항
### captcha 기능 구현
프론트엔드가 보내준 recaptcha v2 코드를 받아 google 서버에서 인증하는 기능을 구현하였다.
![image](https://github.com/user-attachments/assets/e43b5af2-c6cf-4e97-8e80-c14db67c18a3)

- captcha api 호출 같은 경우에는 WebClient를 사용했지만, 이 api에서만 사용되므로 별도의 WebClientUtil은 만들지 않고 CaptchaService에서 바로 외부 api를 호출하도록 하였다.
- recaptcha의 경우, 유저의 ux 편의를 위하여 비교적 간단한 reCaptcha v2를 사용하였다.

## 고려 사항
- 로그인 N회 이상 실패시 captcha 인증 필요 기능을 넣으려면 로그인 실패 횟수를 파악하고 있어야 한다. 하지만 이 부분에 대해서는 구현되지 않았다.