### PR TITLE
Refactor: 이메일 비동기와 트랜잭션 분리 및 도메인 관심사 분리

### DIFF
--- a/backend/src/main/java/kakaobootcamp/backend/domains/email/EmailController.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/email/EmailController.java
@@ -17,6 +17,7 @@ import kakaobootcamp.backend.common.dto.ErrorResponse;
 import kakaobootcamp.backend.domains.email.dto.EmailDTO.SendVerificationCodeRequest;
 import kakaobootcamp.backend.domains.email.dto.EmailDTO.VerifyEmailCodeRequest;
 import kakaobootcamp.backend.domains.email.dto.EmailDTO.VerifyEmailCodeResponse;
+import kakaobootcamp.backend.domains.email.service.EmailVerificationService;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "EMAIL API", description = "이메일에 대한 API입니다.")
@@ -25,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EmailController {
 
-	private final EmailService emailService;
+	private final EmailVerificationService emailVerificationService;
 
 	@PostMapping("/verification-request")
 	@Operation(
@@ -46,7 +47,7 @@ public class EmailController {
 	public ResponseEntity<DataResponse<Void>> sendVerificationCode(
 		@RequestBody @Valid SendVerificationCodeRequest request
 	) {
-		emailService.validateEmailAndSendEmailVerification(request);
+		emailVerificationService.validateEmailAndSendEmailVerification(request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -77,7 +78,7 @@ public class EmailController {
 	public ResponseEntity<DataResponse<VerifyEmailCodeResponse>> verifyEmailCode(
 		@RequestBody @Valid VerifyEmailCodeRequest request
 	) {
-		VerifyEmailCodeResponse response = emailService.verifyEmailCode(request);
+		VerifyEmailCodeResponse response = emailVerificationService.verifyEmailCode(request);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/email/EmailUtil.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/email/EmailUtil.java
@@ -1,0 +1,67 @@
+package kakaobootcamp.backend.domains.email;
+
+import static kakaobootcamp.backend.common.exception.ErrorCode.*;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import kakaobootcamp.backend.common.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class EmailUtil {
+
+	private final JavaMailSender emailSender;
+
+	// 발신할 이메일 데이터 세팅
+	private SimpleMailMessage createEmailForm(
+		String toEmail,
+		String title,
+		String text
+	) {
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(toEmail);
+		message.setSubject(title);
+		message.setText(text);
+
+		return message;
+	}
+
+	// 이메일 보내기
+	@Async
+	public void sendEmail(
+		String toEmail,
+		String title,
+		String text
+	) {
+		SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+
+		int maxRetries = 3;
+		int retryCount = 0;
+		boolean success = false;
+
+		// 이메일 전송 및 실패시 재시도
+		while (retryCount < maxRetries && !success) {
+			try {
+				emailSender.send(emailForm);  // 이메일 전송
+				success = true;
+			} catch (MailException ex) {
+				retryCount++;
+				try {
+					Thread.sleep(5000);  // 5초 대기 후 재시도
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+				}
+			}
+		}
+
+		// 3번 시도 후 실패시 에러 발생
+		if (!success) {
+			throw ApiException.from(EMAIL_BAD_GATEWAY);
+		}
+	}
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/email/service/EmailTokenService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/email/service/EmailTokenService.java
@@ -1,22 +1,32 @@
-package kakaobootcamp.backend.domains.email;
+package kakaobootcamp.backend.domains.email.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kakaobootcamp.backend.common.exception.ApiException;
 import kakaobootcamp.backend.common.exception.ErrorCode;
+import kakaobootcamp.backend.domains.email.domain.EmailToken;
 import kakaobootcamp.backend.domains.email.repository.EmailTokenRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class EmailVerificationService {
+public class EmailTokenService {
 	private final EmailTokenRepository emailTokenRepository;
+
+	// 인증된 이메일 저장
+	@Transactional
+	public void saveEmailToken(String token) {
+		EmailToken emailToken = new EmailToken(token);
+		emailTokenRepository.save(emailToken);
+	}
 
 	// 인증된 토큰 삭제
 	@Transactional
 	public void deleteEmailToken(String token) {
-		emailTokenRepository.deleteById(token);
+		emailTokenRepository
+			.deleteById(token);
 	}
 
 	// 이메일 토큰 확인 및 삭제
@@ -29,6 +39,8 @@ public class EmailVerificationService {
 
 	// 토큰의 유효성을 확인하는 메서드
 	private boolean isTokenValid(String token) {
-		return emailTokenRepository.findById(token).isPresent();
+		return emailTokenRepository
+			.findById(token)
+			.isPresent();
 	}
 }

--- a/backend/src/main/java/kakaobootcamp/backend/domains/email/service/EmailVerificationService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/email/service/EmailVerificationService.java
@@ -1,34 +1,28 @@
-package kakaobootcamp.backend.domains.email;
+package kakaobootcamp.backend.domains.email.service;
 
-import static kakaobootcamp.backend.common.exception.ErrorCode.*;
 import static kakaobootcamp.backend.domains.email.dto.EmailDTO.*;
 
 import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 
-import org.springframework.mail.MailException;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kakaobootcamp.backend.common.exception.ApiException;
 import kakaobootcamp.backend.common.exception.ErrorCode;
+import kakaobootcamp.backend.domains.email.EmailUtil;
 import kakaobootcamp.backend.domains.email.domain.EmailCode;
-import kakaobootcamp.backend.domains.email.domain.EmailToken;
 import kakaobootcamp.backend.domains.email.repository.EmailCodeRepository;
-import kakaobootcamp.backend.domains.email.repository.EmailTokenRepository;
 import kakaobootcamp.backend.domains.member.MemberService;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class EmailService {
+public class EmailVerificationService {
 
-	private final EmailTokenRepository emailTokenRepository;
+	private final EmailTokenService emailTokenService;
 	private final EmailCodeRepository emailCodeRepository;
 	private final MemberService memberService;
 	private final EmailUtil emailUtil;
@@ -71,19 +65,8 @@ public class EmailService {
 
 		// 토큰 발급
 		String token = UUID.randomUUID().toString();
-		saveEmailToken(token);
+		emailTokenService.saveEmailToken(token);
 		return new VerifyEmailCodeResponse(token);
-	}
-
-
-
-
-
-	// 인증된 이메일 저장
-	@Transactional
-	public void saveEmailToken(String token) {
-		EmailToken emailToken = new EmailToken(token);
-		emailTokenRepository.save(emailToken);
 	}
 
 	// 인증 코드 생성

--- a/backend/src/main/java/kakaobootcamp/backend/domains/member/MemberService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/member/MemberService.java
@@ -12,7 +12,7 @@ import kakaobootcamp.backend.common.exception.ApiException;
 import kakaobootcamp.backend.common.exception.ErrorCode;
 import kakaobootcamp.backend.common.util.encoder.EncryptUtil;
 import kakaobootcamp.backend.common.util.encoder.PasswordEncoderUtil;
-import kakaobootcamp.backend.domains.email.EmailVerificationService;
+import kakaobootcamp.backend.domains.email.service.EmailTokenService;
 import kakaobootcamp.backend.domains.member.domain.AutoTradeState;
 import kakaobootcamp.backend.domains.member.domain.LogoutToken;
 import kakaobootcamp.backend.domains.member.domain.Member;
@@ -33,7 +33,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoderUtil passwordEncoderUtil;
 
-	private final EmailVerificationService emailVerificationService;
+	private final EmailTokenService emailTokenService;
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final LogoutRepository logoutRepository;
 
@@ -42,7 +42,7 @@ public class MemberService {
 	public void createMember(CreateMemberRequest request) {
 		// 이메일 검증
 		validateDuplicatedEmail(request.getEmail());
-		emailVerificationService.verifyEmailToken(request.getToken());
+		emailTokenService.verifyEmailToken(request.getToken());
 
 		// 비밀번호 암호화
 		String password = passwordEncoderUtil.encodePassword(request.getPw());


### PR DESCRIPTION
## issue
- close #57 

## 구현 의도 
@Async를 사용할 때에는 메서드 내에서 발생하는 에러를 처리해주지 못한다.
validateDuplicatedEmail에서 예외가 발생해도 예외 메세지를 리턴하지 않고 그대로 200을 리턴한다.
따라서 동기와 비동기 상황을 구분했다.
## 구현 사항
### 비동기와 트랜잭션 분리
![image](https://github.com/user-attachments/assets/ef7e622d-8d14-4b8c-888c-3305eae690b5)
기존 validateEmailAndSendEmailVerification에 Asyn를 제외하고 
sendEail에 대해 별도의 클래스를 생성하였다.
(Async와 Transactional 모두AOP 기반으로 동작하기 때문에 Async가 포함된 메서드를 별도의 클래스로 분리했다.)
이로 인해 sendEmail은 비동기로 작동하고 그 외의 트랜잭션 관린 메서드는 동기로 작동하게 되었다.

### 관심사 분리
이렇게 코드를 분리하고 나니, Email 인증, Email 전송, Email Token에 대해 각각의 관심사가 다르다는 것을 알게 되어 관심사에 맞게 서비스를 분리하였다.


## 🫡 참고사항
https://yooooonshine.tistory.com/38