### PR TITLE
Feature: 해외 주식 매수, 매도 기능 구현(#67)

### DIFF
--- a/backend/src/main/java/kakaobootcamp/backend/common/properties/KisProperties.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/properties/KisProperties.java
@@ -11,10 +11,10 @@ import lombok.Setter;
 public class KisProperties {
 
 	private String url;
-	private String orderTrId;
+	private String buyTrId;
 	private String sellTrId;
-	private String getBalanceTrId;
-	private String getBalanceRealizedProfitAndLossTrId;
-	private String getPriceTrId;
+	private String findBalanceTrId;
+	private String findBalanceRealizedProfitAndLossTrId;
+	private String findPriceTrId;
 	private String findDomesticStockPriceChartId;
 }

--- a/backend/src/main/java/kakaobootcamp/backend/common/properties/KisProperties.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/properties/KisProperties.java
@@ -11,10 +11,28 @@ import lombok.Setter;
 public class KisProperties {
 
 	private String url;
-	private String buyTrId;
-	private String sellTrId;
-	private String findBalanceTrId;
-	private String findBalanceRealizedProfitAndLossTrId;
-	private String findPriceTrId;
-	private String findDomesticStockPriceChartId;
+	private Domestic domestic;
+	private International international;
+
+	@Getter
+	@Setter
+	public static class Domestic {
+		private String buyTrId;
+		private String sellTrId;
+		private String findBalanceTrId;
+		private String findBalanceRealizedProfitAndLossTrId;
+		private String findPriceTrId;
+		private String findDomesticStockPriceChartId;
+	}
+
+	@Getter
+	@Setter
+	public static class International {
+		private String buyTrId;
+		private String sellTrId;
+		private String findBalanceTrId;
+		private String findBalanceRealizedProfitAndLossTrId;
+		private String findPriceTrId;
+		private String findDomesticStockPriceChartId;
+	}
 }

--- a/backend/src/main/java/kakaobootcamp/backend/common/scheduling/SchedulingService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/common/scheduling/SchedulingService.java
@@ -5,7 +5,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.Transactional;
 
 import kakaobootcamp.backend.domains.autoTrade.AutoTradeService;
-import kakaobootcamp.backend.domains.stock.service.StockService;
+import kakaobootcamp.backend.domains.stock.service.DomesticStockService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class SchedulingService {
 
 	private final AutoTradeService autoTradeService;
-	private final StockService stockService;
+	private final DomesticStockService domesticStockService;
 
 	@Async
 	@Scheduled(cron = "0 0 11 * * MON-FRI")
@@ -24,6 +24,6 @@ public class SchedulingService {
 	@Async
 	@Scheduled(cron = "0 0 20 * * MON-SAT")
 	public void updateSuggestedKeywords() {
-		stockService.updateDomesticStocks();
+		domesticStockService.updateDomesticStocks();
 	}
 }

--- a/backend/src/main/java/kakaobootcamp/backend/domains/autoTrade/AutoTradeService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/autoTrade/AutoTradeService.java
@@ -15,10 +15,10 @@ import kakaobootcamp.backend.domains.broker.service.BrokerService;
 import kakaobootcamp.backend.domains.member.MemberService;
 import kakaobootcamp.backend.domains.member.domain.AutoTradeState;
 import kakaobootcamp.backend.domains.member.domain.Member;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockBalanceResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockBalanceResponse.Output1;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.OrderStockRequest;
-import kakaobootcamp.backend.domains.stock.service.StockService;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse.Output1;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockRequest;
+import kakaobootcamp.backend.domains.stock.service.DomesticStockService;
 import kakaobootcamp.backend.domains.transaction.TransactionService;
 import kakaobootcamp.backend.domains.transaction.domain.Transaction;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class AutoTradeService {
 
 	private final AiServerService aiServerService;
-	private final StockService stockService;
+	private final DomesticStockService domesticStockService;
 	private final TransactionService transactionService;
 	private final MemberService memberService;
 	private final BrokerService brokerService;
@@ -52,7 +52,7 @@ public class AutoTradeService {
 		}
 
 		// 현재 보유 주식량 및 예수금 조회
-		GetStockBalanceResponse stockBalanceResponse = stockService.getStockBalance(member, "", "");
+		GetStockBalanceResponse stockBalanceResponse = domesticStockService.getStockBalance(member, "", "");
 
 		// 거래 가능 금액 계산
 		int availableBalance = calculateAvailableBalance(
@@ -127,9 +127,9 @@ public class AutoTradeService {
 			.build();
 
 		if (isBuy) {
-			stockService.orderStock(member, request);
+			domesticStockService.orderStock(member, request);
 		} else {
-			stockService.sellStock(member, request);
+			domesticStockService.sellStock(member, request);
 		}
 	}
 }

--- a/backend/src/main/java/kakaobootcamp/backend/domains/autoTrade/AutoTradeService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/autoTrade/AutoTradeService.java
@@ -15,8 +15,8 @@ import kakaobootcamp.backend.domains.broker.service.BrokerService;
 import kakaobootcamp.backend.domains.member.MemberService;
 import kakaobootcamp.backend.domains.member.domain.AutoTradeState;
 import kakaobootcamp.backend.domains.member.domain.Member;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse.Output1;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockBalanceResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockBalanceResponse.Output1;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockRequest;
 import kakaobootcamp.backend.domains.stock.service.DomesticStockService;
 import kakaobootcamp.backend.domains.transaction.TransactionService;
@@ -52,7 +52,7 @@ public class AutoTradeService {
 		}
 
 		// 현재 보유 주식량 및 예수금 조회
-		GetStockBalanceResponse stockBalanceResponse = domesticStockService.getStockBalance(member, "", "");
+		FindStockBalanceResponse stockBalanceResponse = domesticStockService.findStockBalance(member, "", "");
 
 		// 거래 가능 금액 계산
 		int availableBalance = calculateAvailableBalance(
@@ -127,9 +127,9 @@ public class AutoTradeService {
 			.build();
 
 		if (isBuy) {
-			domesticStockService.orderStock(member, request);
+			domesticStockService.orderStock(member, request, true);
 		} else {
-			domesticStockService.sellStock(member, request);
+			domesticStockService.orderStock(member, request, false);
 		}
 	}
 }

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/controller/DomesticStockController.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/controller/DomesticStockController.java
@@ -25,31 +25,31 @@ import kakaobootcamp.backend.common.dto.DataResponse;
 import kakaobootcamp.backend.common.dto.ErrorResponse;
 import kakaobootcamp.backend.common.util.memberLoader.MemberLoader;
 import kakaobootcamp.backend.domains.member.domain.Member;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.FindDomesticStockPopularChartResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.FindDomesticStockPriceChartResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.FindSuggestedKeywordResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockBalanceRealizedProfitAndLossResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockBalanceResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockPriceResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.OrderStockRequest;
-import kakaobootcamp.backend.domains.stock.service.StockService;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindDomesticStockPopularChartResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockPriceChartResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindSuggestedKeywordResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceRealizedProfitAndLossResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockPriceResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockRequest;
+import kakaobootcamp.backend.domains.stock.service.DomesticStockService;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "STOCK API", description = "주식에 대한 API입니다.")
+@Tag(name = "DOMESTIC STOCK API", description = "국내 주식에 대한 API입니다.")
 @RestController
-@RequestMapping("/api/stocks")
+@RequestMapping("/api/stocks/domestic")
 @RequiredArgsConstructor
-public class StockController {
+public class DomesticStockController {
 
 	private final MemberLoader memberLoader;
-	private final StockService stockService;
+	private final DomesticStockService domesticStockService;
 
 	// 삭제될 API
 	@PostMapping("/buy")
 	public ResponseEntity<DataResponse<Void>> buyStock(OrderStockRequest request) {
 		Member member = memberLoader.getMember();
 
-		stockService.orderStock(member, request);
+		domesticStockService.orderStock(member, request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -58,7 +58,7 @@ public class StockController {
 	public ResponseEntity<DataResponse<Void>> sellStock(OrderStockRequest request) {
 		Member member = memberLoader.getMember();
 
-		stockService.sellStock(member, request);
+		domesticStockService.sellStock(member, request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -122,7 +122,7 @@ public class StockController {
 		@RequestParam(name = "CTX_AREA_NK100", defaultValue = "") String nk) {
 		Member member = memberLoader.getMember();
 
-		GetStockBalanceResponse response = stockService.getStockBalance(member, fk, nk);
+		GetStockBalanceResponse response = domesticStockService.getStockBalance(member, fk, nk);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
@@ -158,7 +158,7 @@ public class StockController {
 	public ResponseEntity<DataResponse<GetStockBalanceRealizedProfitAndLossResponse>> getBalanceRealizedProfitAndLoss() {
 		Member member = memberLoader.getMember();
 
-		GetStockBalanceRealizedProfitAndLossResponse response = stockService
+		GetStockBalanceRealizedProfitAndLossResponse response = domesticStockService
 			.getBalanceRealizedProfitAndLoss(member);
 
 		return ResponseEntity.ok(DataResponse.from(response));
@@ -195,7 +195,7 @@ public class StockController {
 		@RequestParam("productNumber") String productNumber) {
 		Member member = memberLoader.getMember();
 
-		GetStockPriceResponse response = stockService.getStockPrice(member, productNumber);
+		GetStockPriceResponse response = domesticStockService.getStockPrice(member, productNumber);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
@@ -229,14 +229,14 @@ public class StockController {
 	)
 	public ResponseEntity<DataResponse<List<FindSuggestedKeywordResponse>>> findSuggestedKeywords(
 		@RequestParam("keyword") String keyword) {
-		List<FindSuggestedKeywordResponse> responses = stockService.findSuggestedKeywords(keyword);
+		List<FindSuggestedKeywordResponse> responses = domesticStockService.findSuggestedKeywords(keyword);
 
 		return ResponseEntity.ok(DataResponse.from(responses));
 	}
 
 	@GetMapping("/update/removed")
 	public ResponseEntity<?> updateRemovedStocks() {
-		stockService.updateDomesticStocks();
+		domesticStockService.updateDomesticStocks();
 
 		return ResponseEntity.ok().build();
 	}
@@ -269,12 +269,12 @@ public class StockController {
 			)
 		}
 	)
-	public ResponseEntity<DataResponse<FindDomesticStockPriceChartResponse>> findDomesticStockPriceChart(
+	public ResponseEntity<DataResponse<FindStockPriceChartResponse>> findStockPriceChart(
 		@RequestParam("productNumber") String productNumber,
 		@Pattern(regexp = "D|W|M|Y", message = "periodCode는 D, W, M, Y 중 하나여야 합니다.") @RequestParam("periodCode") String periodCode) {
 		Member member = memberLoader.getMember();
 
-		FindDomesticStockPriceChartResponse response = stockService.findDomesticStockPriceChart(member, productNumber,
+		FindStockPriceChartResponse response = domesticStockService.findStockPriceChart(member, productNumber,
 			periodCode);
 
 		return ResponseEntity.ok(DataResponse.from(response));

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/controller/DomesticStockController.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/controller/DomesticStockController.java
@@ -26,11 +26,11 @@ import kakaobootcamp.backend.common.dto.ErrorResponse;
 import kakaobootcamp.backend.common.util.memberLoader.MemberLoader;
 import kakaobootcamp.backend.domains.member.domain.Member;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindDomesticStockPopularChartResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockBalanceRealizedProfitAndLossResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockBalanceResponse;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockPriceChartResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockPriceResponse;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindSuggestedKeywordResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceRealizedProfitAndLossResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockPriceResponse;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockRequest;
 import kakaobootcamp.backend.domains.stock.service.DomesticStockService;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +49,7 @@ public class DomesticStockController {
 	public ResponseEntity<DataResponse<Void>> buyStock(OrderStockRequest request) {
 		Member member = memberLoader.getMember();
 
-		domesticStockService.orderStock(member, request);
+		domesticStockService.orderStock(member, request, true);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -58,13 +58,13 @@ public class DomesticStockController {
 	public ResponseEntity<DataResponse<Void>> sellStock(OrderStockRequest request) {
 		Member member = memberLoader.getMember();
 
-		domesticStockService.sellStock(member, request);
+		domesticStockService.orderStock(member, request, false);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
 	@GetMapping("/recommendations")
-	public ResponseEntity<DataResponse<List<FindDomesticStockPopularChartResponse>>> getStockRecommendations(
+	public ResponseEntity<DataResponse<List<FindDomesticStockPopularChartResponse>>> findStockRecommendations(
 		@RequestParam("size") @Min(value = 1, message = "size는 1이상이어야 합니다.") @Max(value = 10, message = "size는 10이하이어야 합니다.") int size,
 		@RequestParam("page") @Min(value = 0, message = "page는 0이상이어야 합니다.") int page) {
 		Pageable pageable = PageRequest.of(page, size);
@@ -117,12 +117,12 @@ public class DomesticStockController {
 			)
 		}
 	)
-	public ResponseEntity<DataResponse<GetStockBalanceResponse>> getStockBalance(
+	public ResponseEntity<DataResponse<FindStockBalanceResponse>> findStockBalance(
 		@RequestParam(name = "CTX_AREA_FK100", defaultValue = "") String fk,
 		@RequestParam(name = "CTX_AREA_NK100", defaultValue = "") String nk) {
 		Member member = memberLoader.getMember();
 
-		GetStockBalanceResponse response = domesticStockService.getStockBalance(member, fk, nk);
+		FindStockBalanceResponse response = domesticStockService.findStockBalance(member, fk, nk);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
@@ -155,11 +155,11 @@ public class DomesticStockController {
 			)
 		}
 	)
-	public ResponseEntity<DataResponse<GetStockBalanceRealizedProfitAndLossResponse>> getBalanceRealizedProfitAndLoss() {
+	public ResponseEntity<DataResponse<FindStockBalanceRealizedProfitAndLossResponse>> findBalanceRealizedProfitAndLoss() {
 		Member member = memberLoader.getMember();
 
-		GetStockBalanceRealizedProfitAndLossResponse response = domesticStockService
-			.getBalanceRealizedProfitAndLoss(member);
+		FindStockBalanceRealizedProfitAndLossResponse response = domesticStockService
+			.findBalanceRealizedProfitAndLoss(member);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
@@ -191,11 +191,11 @@ public class DomesticStockController {
 			)
 		}
 	)
-	public ResponseEntity<DataResponse<GetStockPriceResponse>> getStockPrice(
+	public ResponseEntity<DataResponse<FindStockPriceResponse>> findStockPrice(
 		@RequestParam("productNumber") String productNumber) {
 		Member member = memberLoader.getMember();
 
-		GetStockPriceResponse response = domesticStockService.getStockPrice(member, productNumber);
+		FindStockPriceResponse response = domesticStockService.findStockPrice(member, productNumber);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/controller/InternationalStockController.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/controller/InternationalStockController.java
@@ -1,0 +1,43 @@
+package kakaobootcamp.backend.domains.stock.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kakaobootcamp.backend.common.dto.DataResponse;
+import kakaobootcamp.backend.common.util.memberLoader.MemberLoader;
+import kakaobootcamp.backend.domains.member.domain.Member;
+import kakaobootcamp.backend.domains.stock.dto.InternationalStockDTO.InternationalOrderStockRequest;
+import kakaobootcamp.backend.domains.stock.service.InternationalStockService;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "INTERNATIONAL STOCK API", description = "해외 주식에 대한 API입니다.")
+@RestController
+@RequestMapping("/api/stock/international")
+@RequiredArgsConstructor
+public class InternationalStockController {
+
+	private final MemberLoader memberLoader;
+	private final InternationalStockService internationalStockService;
+
+	// 삭제될 API
+	@PostMapping("/buy")
+	public ResponseEntity<DataResponse<Void>> buyStock(InternationalOrderStockRequest request) {
+		Member member = memberLoader.getMember();
+
+		internationalStockService.orderStock(member, request, true);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@PostMapping("/sell")
+	public ResponseEntity<DataResponse<Void>> sellStock(InternationalOrderStockRequest request) {
+		Member member = memberLoader.getMember();
+
+		internationalStockService.orderStock(member, request, false);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
@@ -18,15 +18,6 @@ public class DomesticStockDTO {
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class KisBaseResponse {
-
-		private String rt_cd; // 응답 코드
-		private String msg_cd; // 메시지 코드
-		private String msg1; // 메시지 내용
-	}
-
-	@Getter
-	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	@Builder
 	public static class OrderStockRequest {

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
@@ -26,11 +26,29 @@ public class DomesticStockDTO {
 	}
 
 	@Getter
-	@Setter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	@Builder
 	public static class OrderStockRequest {
+		@JsonProperty("PDNO")
+		private String PDNO; // 종목코드 (6자리, 최대 12자리)
+
+		@JsonProperty("ORD_DVSN")
+		private String ORD_DVSN; // 주문구분 (2자리)
+
+		@JsonProperty("ORD_QTY")
+		private String ORD_QTY; // 주문수량 (최대 10자리)
+
+		@JsonProperty("ORD_UNPR")
+		private String ORD_UNPR; // 주문단가 (최대 19자리)
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	@Builder
+	public static class KisOrderStockRequest {
 
 		@JsonProperty("CANO")
 		private String CANO; // 종합계좌번호 (8자리)

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-public class StockDTO {
+public class DomesticStockDTO {
 
 	@Getter
 	@Setter
@@ -411,7 +411,7 @@ public class StockDTO {
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class FindDomesticStockPriceChartResponse extends KisBaseResponse {
+	public static class FindStockPriceChartResponse extends KisBaseResponse {
 
 		private Output1 output1;  // 응답 상세
 		private List<Output2> output2;  // 일별 데이터 배열

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/DomesticStockDTO.java
@@ -17,26 +17,6 @@ import lombok.Setter;
 public class DomesticStockDTO {
 
 	@Getter
-	@Setter
-	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	@Builder
-	@AllArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class OrderStockRequest {
-
-		@JsonProperty("PDNO")
-		private String PDNO; // 종목코드 (6자리, 최대 12자리)
-
-		@JsonProperty("ORD_DVSN")
-		private String ORD_DVSN; // 주문구분 (2자리)
-
-		@JsonProperty("ORD_QTY")
-		private String ORD_QTY; // 주문수량 (최대 10자리)
-
-		@JsonProperty("ORD_UNPR")
-		private String ORD_UNPR; // 주문단가 (최대 19자리)
-	}
-
-	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class KisBaseResponse {
 
@@ -50,7 +30,7 @@ public class DomesticStockDTO {
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	@Builder
-	public static class KisOrderStockRequest {
+	public static class OrderStockRequest {
 
 		@JsonProperty("CANO")
 		private String CANO; // 종합계좌번호 (8자리)
@@ -94,7 +74,7 @@ public class DomesticStockDTO {
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class GetStockBalanceResponse extends KisBaseResponse {
+	public static class FindStockBalanceResponse extends KisBaseResponse {
 
 		private String ctx_area_fk100; // 연속조회검색조건100
 		private String ctx_area_nk100; // 연속조회키100
@@ -164,7 +144,7 @@ public class DomesticStockDTO {
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class GetStockBalanceRealizedProfitAndLossResponse extends KisBaseResponse {
+	public static class FindStockBalanceRealizedProfitAndLossResponse extends KisBaseResponse {
 
 		private List<Output1> output1; // 응답상세1 (Object Array)
 		private List<Output2> output2; // 응답상세2 (Object)
@@ -233,7 +213,7 @@ public class DomesticStockDTO {
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class GetStockPriceResponse extends KisBaseResponse {
+	public static class FindStockPriceResponse extends KisBaseResponse {
 
 		private Output output; // 응답상세
 

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/InternationalStockDTO.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/InternationalStockDTO.java
@@ -1,0 +1,67 @@
+package kakaobootcamp.backend.domains.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class InternationalStockDTO {
+
+	@Data
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	@Builder
+	public static class InternationalOrderStockRequest {
+
+		@JsonProperty("CANO")
+		private String CANO; // 고객계좌번호
+
+		@JsonProperty("ACNT_PRDT_CD")
+		private String ACNT_PRDT_CD; // 계좌상품코드
+
+		@JsonProperty("OVRS_EXCG_CD")
+		private String OVRS_EXCG_CD; // 해외거래소코드
+
+		@JsonProperty("PDNO")
+		private String PDNO; // 종목코드 (6자리, 최대 12자리)
+
+		@JsonProperty("ORD_QTY")
+		private String ORD_QTY; // 주문수량 (최대 10자리)
+
+		@JsonProperty("OVRS_ORD_UNPR")
+		private String OVRS_ORD_UNPR; // 해외주문단가 (최대 10자리)
+
+		@JsonProperty("SLL_TYPE")
+		private final String SLL_TYPE;
+
+		@JsonProperty("ORD_SVR_DVSN_CD")
+		private final String ORD_SVR_DVSN_CD;
+
+		@JsonProperty("ORD_DVSN")
+		private String ORD_DVSN;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class OrderStockResponse extends KisBaseResponse {
+		// 출력 데이터
+		private Output output;
+
+		@Getter
+		@NoArgsConstructor(access = AccessLevel.PRIVATE)
+		public static class Output {
+
+			// KRX 전달 주문 원본 번호
+			private String KRX_FWDG_ORD_ORGNO;
+
+			// 주문 번호
+			private String ODNO;
+
+			// 주문 시간
+			private String ORD_TMD;
+		}
+	}
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/KisBaseResponse.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/KisBaseResponse.java
@@ -1,11 +1,8 @@
 package kakaobootcamp.backend.domains.stock.dto;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KisBaseResponse {
 
 	private String rt_cd; // 응답 코드

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/KisBaseResponse.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/dto/KisBaseResponse.java
@@ -1,0 +1,14 @@
+package kakaobootcamp.backend.domains.stock.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KisBaseResponse {
+
+	private String rt_cd; // 응답 코드
+	private String msg_cd; // 메시지 코드
+	private String msg1; // 메시지 내용
+}

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
@@ -54,8 +54,8 @@ public class DomesticStockService {
 
 	// 헤더 설정
 	private Map<String, String> makeHeaders(Member member, String trId) {
-		KisAccessToken kisAccessToken = kisAccessTokenService.findKisAccessToken(member.getId()).
-			orElseThrow(() -> ApiException.from(KIS_ACCESS_TOKEN_NOT_FOUND));
+		KisAccessToken kisAccessToken = kisAccessTokenService.findKisAccessToken(member.getId())
+			.orElseThrow(() -> ApiException.from(KIS_ACCESS_TOKEN_NOT_FOUND));
 		String accessToken = kisAccessToken.getAccessToken();
 
 		Map<String, String> headers = new HashMap<>();
@@ -77,9 +77,9 @@ public class DomesticStockService {
 	// TrId 조회
 	private String getTrId(boolean isBuy) {
 		if (isBuy) {
-			return kisProperties.getBuyTrId();
+			return kisProperties.getDomestic().getBuyTrId();
 		} else {
-			return kisProperties.getSellTrId();
+			return kisProperties.getDomestic().getSellTrId();
 		}
 	}
 
@@ -122,7 +122,7 @@ public class DomesticStockService {
 		String uri = "/uapi/domestic-stock/v1/trading/inquire-balance";
 
 		// 헤더 설정
-		Map<String, String> headers = makeHeaders(member, kisProperties.getFindBalanceTrId());
+		Map<String, String> headers = makeHeaders(member, kisProperties.getDomestic().getFindBalanceTrId());
 
 		// 파라미터 설정
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -154,7 +154,7 @@ public class DomesticStockService {
 		String uri = "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl";
 
 		// 헤더 설정
-		Map<String, String> headers = makeHeaders(member, kisProperties.getFindBalanceRealizedProfitAndLossTrId());
+		Map<String, String> headers = makeHeaders(member, kisProperties.getDomestic().getFindBalanceRealizedProfitAndLossTrId());
 		headers.put("custtype", "P"); // 고객타입(P: 개인, B: 기업)
 
 		// 파라미터 설정
@@ -188,7 +188,7 @@ public class DomesticStockService {
 		String uri = "/uapi/domestic-stock/v1/quotations/inquire-price";
 
 		// 헤더 설정
-		Map<String, String> headers = makeHeaders(member, kisProperties.getFindPriceTrId());
+		Map<String, String> headers = makeHeaders(member, kisProperties.getDomestic().getFindPriceTrId());
 
 		// 파라미터 설정
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -308,7 +308,7 @@ public class DomesticStockService {
 		String endDate = makeDateToString(today);
 
 		// 헤더 설정
-		Map<String, String> headers = makeHeaders(member, kisProperties.getFindDomesticStockPriceChartId());
+		Map<String, String> headers = makeHeaders(member, kisProperties.getDomestic().getFindDomesticStockPriceChartId());
 
 		// 파라미터 설정
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
@@ -25,17 +25,17 @@ import kakaobootcamp.backend.domains.broker.service.KisAccessTokenService;
 import kakaobootcamp.backend.domains.member.MemberService;
 import kakaobootcamp.backend.domains.member.domain.Member;
 import kakaobootcamp.backend.domains.stock.domain.DomesticStock;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.FindDomesticStockPriceChartResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.FindSuggestedKeywordResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockBalanceRealizedProfitAndLossResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockBalanceResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetStockPriceResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetSuggestedKeywordsDTO;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.GetSuggestedKeywordsDTO.Response.Body.Items.Item;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.KisBaseResponse;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.KisOrderStockRequest;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.OrderStockRequest;
-import kakaobootcamp.backend.domains.stock.dto.StockDTO.OrderStockResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockPriceChartResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindSuggestedKeywordResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceRealizedProfitAndLossResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockBalanceResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetStockPriceResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetSuggestedKeywordsDTO;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetSuggestedKeywordsDTO.Response.Body.Items.Item;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.KisBaseResponse;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.KisOrderStockRequest;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockRequest;
+import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockResponse;
 import kakaobootcamp.backend.domains.stock.repository.DomesticStockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class StockService {
+public class DomesticStockService {
 
 	private final KisProperties kisProperties;
 	private final KisAccessTokenService kisAccessTokenService;
@@ -312,7 +312,7 @@ public class StockService {
 	}
 
 	// 국내 주식 기간별 시세 조회
-	public FindDomesticStockPriceChartResponse findDomesticStockPriceChart(Member member, String productNumber,
+	public FindStockPriceChartResponse findStockPriceChart(Member member, String productNumber,
 		String periodCode) {
 		String uri = "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
 		LocalDate today = LocalDate.now();
@@ -331,11 +331,11 @@ public class StockService {
 		params.add("FID_PERIOD_DIV_CODE", periodCode);
 		params.add("FID_ORG_ADJ_PRC", "1");
 
-		FindDomesticStockPriceChartResponse response = webClientUtil.getFromKis(
+		FindStockPriceChartResponse response = webClientUtil.getFromKis(
 			headers,
 			uri,
 			params,
-			FindDomesticStockPriceChartResponse.class);
+			FindStockPriceChartResponse.class);
 
 		checkResponse(response);
 

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
@@ -1,6 +1,7 @@
 package kakaobootcamp.backend.domains.stock.service;
 
 import static kakaobootcamp.backend.common.exception.ErrorCode.*;
+import static kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -25,16 +26,7 @@ import kakaobootcamp.backend.domains.broker.service.KisAccessTokenService;
 import kakaobootcamp.backend.domains.member.MemberService;
 import kakaobootcamp.backend.domains.member.domain.Member;
 import kakaobootcamp.backend.domains.stock.domain.DomesticStock;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockPriceChartResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindSuggestedKeywordResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockBalanceRealizedProfitAndLossResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockBalanceResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.FindStockPriceResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetSuggestedKeywordsDTO;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetSuggestedKeywordsDTO.Response.Body.Items.Item;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.KisBaseResponse;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockRequest;
-import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.OrderStockResponse;
 import kakaobootcamp.backend.domains.stock.repository.DomesticStockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -92,22 +84,22 @@ public class DomesticStockService {
 		Map<String, String> headers = makeHeaders(member, trId);
 
 		// 본문 설정
-		OrderStockRequest orderStockRequest = makeKisOrderStockRequestFromOrderStockRequestAndMember(member,
+		KisOrderStockRequest kisOrderStockRequest = makeKisOrderStockRequestFromOrderStockRequestAndMember(member,
 			request);
 
 		OrderStockResponse response = webClientUtil.postFromKis(
 			headers,
 			uri,
-			orderStockRequest,
+			kisOrderStockRequest,
 			OrderStockResponse.class);
 
 		checkResponse(response);
 	}
 
 	// KisOrderStockRequest를 OrderStockRequest와 Member로 만들어주는 메서드
-	private OrderStockRequest makeKisOrderStockRequestFromOrderStockRequestAndMember(Member member,
+	private KisOrderStockRequest makeKisOrderStockRequestFromOrderStockRequestAndMember(Member member,
 		OrderStockRequest request) {
-		return OrderStockRequest.builder()
+		return KisOrderStockRequest.builder()
 			.CANO(member.getComprehensiveAccountNumber())
 			.ACNT_PRDT_CD(member.getAccountProductCode())
 			.PDNO(request.getPDNO())
@@ -154,7 +146,8 @@ public class DomesticStockService {
 		String uri = "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl";
 
 		// 헤더 설정
-		Map<String, String> headers = makeHeaders(member, kisProperties.getDomestic().getFindBalanceRealizedProfitAndLossTrId());
+		Map<String, String> headers = makeHeaders(member,
+			kisProperties.getDomestic().getFindBalanceRealizedProfitAndLossTrId());
 		headers.put("custtype", "P"); // 고객타입(P: 개인, B: 기업)
 
 		// 파라미터 설정
@@ -308,7 +301,8 @@ public class DomesticStockService {
 		String endDate = makeDateToString(today);
 
 		// 헤더 설정
-		Map<String, String> headers = makeHeaders(member, kisProperties.getDomestic().getFindDomesticStockPriceChartId());
+		Map<String, String> headers = makeHeaders(member,
+			kisProperties.getDomestic().getFindDomesticStockPriceChartId());
 
 		// 파라미터 설정
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/DomesticStockService.java
@@ -27,6 +27,7 @@ import kakaobootcamp.backend.domains.member.MemberService;
 import kakaobootcamp.backend.domains.member.domain.Member;
 import kakaobootcamp.backend.domains.stock.domain.DomesticStock;
 import kakaobootcamp.backend.domains.stock.dto.DomesticStockDTO.GetSuggestedKeywordsDTO.Response.Body.Items.Item;
+import kakaobootcamp.backend.domains.stock.dto.KisBaseResponse;
 import kakaobootcamp.backend.domains.stock.repository.DomesticStockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/InternationalStockService.java
+++ b/backend/src/main/java/kakaobootcamp/backend/domains/stock/service/InternationalStockService.java
@@ -1,0 +1,80 @@
+package kakaobootcamp.backend.domains.stock.service;
+
+import static kakaobootcamp.backend.common.exception.ErrorCode.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import kakaobootcamp.backend.common.exception.ApiException;
+import kakaobootcamp.backend.common.properties.KisProperties;
+import kakaobootcamp.backend.common.util.webClient.WebClientUtil;
+import kakaobootcamp.backend.domains.broker.KisAccessToken;
+import kakaobootcamp.backend.domains.broker.service.KisAccessTokenService;
+import kakaobootcamp.backend.domains.member.MemberService;
+import kakaobootcamp.backend.domains.member.domain.Member;
+import kakaobootcamp.backend.domains.stock.dto.InternationalStockDTO.InternationalOrderStockRequest;
+import kakaobootcamp.backend.domains.stock.dto.InternationalStockDTO.OrderStockResponse;
+import kakaobootcamp.backend.domains.stock.dto.KisBaseResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InternationalStockService {
+
+	private final KisProperties kisProperties;
+	private final KisAccessTokenService kisAccessTokenService;
+	private final MemberService memberService;
+	private final WebClientUtil webClientUtil;
+
+	// 헤더 설정
+	private Map<String, String> makeHeaders(Member member, String trId) {
+		KisAccessToken kisAccessToken = kisAccessTokenService.findKisAccessToken(member.getId())
+			.orElseThrow(() -> ApiException.from(KIS_ACCESS_TOKEN_NOT_FOUND));
+		String accessToken = kisAccessToken.getAccessToken();
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("authorization", accessToken);
+		headers.put("appkey", memberService.getDecryptedAppKey(member));
+		headers.put("appsecret", memberService.getDecryptedSecretKey(member));
+		headers.put("tr_id", trId);
+
+		return headers;
+	}
+
+	// 응답 확인
+	private void checkResponse(KisBaseResponse response) {
+		if (!response.getRt_cd().equals("0")) {
+			throw ApiException.of(HttpStatus.BAD_REQUEST, response.getMsg1());
+		}
+	}
+
+	// TrId 조회
+	private String getTrId(boolean isBuy) {
+		if (isBuy) {
+			return kisProperties.getInternational().getBuyTrId();
+		} else {
+			return kisProperties.getInternational().getSellTrId();
+		}
+	}
+
+	// 주식 사기
+	public void orderStock(Member member, InternationalOrderStockRequest request, boolean isBuy) {
+		String uri = "/uapi/overseas-stock/v1/trading/order";
+		String trId = getTrId(isBuy);
+
+		// 헤더 설정
+		Map<String, String> headers = makeHeaders(member, trId);
+
+		// 본문 설정
+		OrderStockResponse response = webClientUtil.postFromKis(
+			headers,
+			uri,
+			request,
+			OrderStockResponse.class);
+
+		checkResponse(response);
+	}
+}


### PR DESCRIPTION
## issue
- close #67 

## 구현 의도 
 기존 국내 주식 서비스에서 해외주식 구매까지 확장하려한다.
따라서 기존의 주식 -> 국내 주식으로 변경하고, 해외주식  구매 코드를 구현한다.

## 구현 사항
### 기존 stock ->  domesticStock으로 변경

### 미국 주식 매수, 매도 기능
![image](https://github.com/user-attachments/assets/2e644c04-02c0-48b5-bc3a-831dabbd4986)
webClient를 통해 주식 주문 기능을 구현하였다. 

## 🫡 참고사항
- 미국 주식은 시장가 구매 기능이 없다. 따라서 지정가만 가능하므로 별도로 가격 조회하는 기능을 넣어야 한다.
- 주식 주문 기능은 webClient를 호출한 이후로는 추가로 로직이 진행되고 있지 않다. 따라서 이를 비동기화해 성능을 개선할 수 있을 거 같다.
